### PR TITLE
Fix misplaced sos-eos metrics

### DIFF
--- a/R/PhenoTrs.R
+++ b/R/PhenoTrs.R
@@ -83,7 +83,8 @@ function(
     greenup[ratio.deriv < 0] <- FALSE
     return(greenup)
 }
-	greenup <- .Greenup(ratio)
+	greenup <- .Greenup(ratio) & index(ratio) < pop
+	senescence <- !.Greenup(ratio) & index(ratio) >= pop
 			
 	# select time where SOS and EOS are located (around trs value)
 	bool <- ratio >= trs.low & ratio <= trs.up
@@ -91,7 +92,7 @@ function(
 	# get SOS, EOS, LOS
 	soseos <- index(x)
 	sos <- round(median(soseos[greenup & bool], na.rm=TRUE))
-	eos <- round(median(soseos[!greenup & bool], na.rm=TRUE))
+	eos <- round(median(soseos[senescence & bool], na.rm=TRUE))
 	los <- eos - sos
 	los[los < 0] <- n + (eos[los < 0] - sos[los < 0])
 	


### PR DESCRIPTION
Dear @gianlucafilippa ,
sometimes SOS-EOS dates appears to be misplaced, in particular when half-double-logistics fitted curves are not monotonic (e.g., if the second part of the double-logistic curve is decreasing and then increasing, the estimated sos date could be placed in this increasing segment - after eos - instead than ìn the first part of the curve). This PR should fix that.

Ps. thanks for your very useful package; I am planning to using it as dependence in a package which I am writing to analyse Sentinel-2-derived time series.